### PR TITLE
Fix the required checkbox getting unchecked when updating question

### DIFF
--- a/webapp/src/lib/components/editor/questions/checkbox.svelte
+++ b/webapp/src/lib/components/editor/questions/checkbox.svelte
@@ -139,7 +139,7 @@
     <Checkbox 
       id="required-{question.id}" 
       checked={question.required}
-      onchange={() => store.updateQuestion(questionId, { required: !question.required })}
+      onCheckedChange={(v) => store.updateQuestion(questionId, { required: !!v })}
     />
     <Label for="required-{question.id}" class="text-sm">
       Required

--- a/webapp/src/lib/components/editor/questions/date.svelte
+++ b/webapp/src/lib/components/editor/questions/date.svelte
@@ -30,7 +30,7 @@
     <Checkbox 
       id="required-{question.id}" 
       checked={question.required} 
-      onchange={() => store.updateQuestion(questionId, { required: !question.required })}
+      onCheckedChange={(v) => store.updateQuestion(questionId, { required: !!v })}
     />
     <Label for="required-{question.id}" class="text-sm font-normal cursor-pointer">
       Required field

--- a/webapp/src/lib/components/editor/questions/file.svelte
+++ b/webapp/src/lib/components/editor/questions/file.svelte
@@ -183,7 +183,7 @@
     <Checkbox
       id="required-{question.id}"
       checked={question.required}
-      onchange={() => store.updateQuestion(questionId, { required: !question.required })}
+      onCheckedChange={(v) => store.updateQuestion(questionId, { required: !!v })}
     />
     <Label for="required-{question.id}" class="text-sm font-normal cursor-pointer">
       Required field

--- a/webapp/src/lib/components/editor/questions/input.svelte
+++ b/webapp/src/lib/components/editor/questions/input.svelte
@@ -243,7 +243,7 @@
       <Checkbox
         id="required-{question.id}"
         checked={question.required}
-        onchange={() => store.updateQuestion(questionId, { required: !question.required })}
+        onCheckedChange={(v) => store.updateQuestion(questionId, { required: !!v })}
       />
       <Label for="required-{question.id}" class="text-sm"> Required </Label>
     </div>

--- a/webapp/src/lib/components/editor/questions/radio.svelte
+++ b/webapp/src/lib/components/editor/questions/radio.svelte
@@ -135,7 +135,7 @@
     <Checkbox 
       id="required-{question.id}" 
       checked={question.required}
-      onchange={() => store.updateQuestion(questionId, { required: !question.required })}
+      onCheckedChange={(v) => store.updateQuestion(questionId, { required: !!v })}
     />
     <Label for="required-{question.id}" class="text-sm">
       Required

--- a/webapp/src/lib/components/editor/questions/select.svelte
+++ b/webapp/src/lib/components/editor/questions/select.svelte
@@ -135,7 +135,7 @@
 		<Checkbox 
       id="required-{question.id}" 
       checked={question.required}
-      onchange={() => store.updateQuestion(questionId, { required: !question.required })}
+      onCheckedChange={(v) => store.updateQuestion(questionId, { required: !!v })}
     />
 		<Label for="required-{question.id}" class="text-sm">
 			Required

--- a/webapp/src/lib/components/editor/questions/textarea.svelte
+++ b/webapp/src/lib/components/editor/questions/textarea.svelte
@@ -243,7 +243,7 @@
       <Checkbox
         id="required-{question.id}"
         checked={question.required}
-        onchange={() => store.updateQuestion(questionId, { required: !question.required })}
+        onCheckedChange={(v) => store.updateQuestion(questionId, { required: !!v })}
       />
       <Label for="required-{question.id}" class="text-sm"> Required </Label>
     </div>


### PR DESCRIPTION
When the 'Required' checkbox is clicked, `store.updateQuestion` is never called. This is because the checkbox component doesn't use an `onchange` callback. Changing it to `onCheckedChange` fixes the issue.